### PR TITLE
add comments as a top-level object

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -59,6 +59,18 @@ var trackType = new GraphQLObjectType({
       resolve: (root) => {
         return JSONDataWithPath('/users/' + root.user_id);
       }
+    },
+    commentsConnection: {
+      type: new GraphQLList(commentType),
+      args: {
+        limit: { type: GraphQLInt }
+      },
+      description: 'The comments posted on this track.',
+      resolve: (root, args) => {
+        return JSONDataWithPath(
+          '/tracks/' + root.id +
+          '/comments?limit=' + args.limit);
+      }
     }
   })
 });
@@ -117,6 +129,18 @@ var userType = new GraphQLObjectType({
         return JSONDataWithPath(
           '/users/' + root.id +
           '/tracks?limit=' + args.limit);
+      }
+    },
+    commentsConnection: {
+      type: new GraphQLList(commentType),
+      args: {
+        limit: { type: GraphQLInt }
+      },
+      description: 'The comments posted by this user.',
+      resolve: (root, args) => {
+        return JSONDataWithPath(
+          '/users/' + root.id +
+          '/comments?limit=' + args.limit);
       }
     }
   })

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -173,6 +173,41 @@ var playlistType = new GraphQLObjectType({
   })
 });
 
+var commentType = new GraphQLObjectType({
+  name: 'Comment',
+  fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The identifier of the comment.',
+      resolve: (comment) => comment.id
+    },
+    body: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The HTML body of the comment.',
+      resolve: (comment) => comment.body
+    },
+    timestamp: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'The comment is on this point in the track. (milliseconds)',
+      resolve: (comment) => comment.timestamp
+    },
+    userConnection: {
+      type: userType,
+      description: 'The user who made the comment.',
+      resolve: (root) => {
+        return JSONDataWithPath('/users/' + root.user_id);
+      }
+    },
+    trackConnection: {
+      type: trackType,
+      description: 'The track this comment is on.',
+      resolve: (root) => {
+        return JSONDataWithPath('/tracks/' + root.track_id);
+      }
+    }
+  })
+});
+
 var rootType = new GraphQLObjectType({
   name: 'Root',
   fields: () => ({
@@ -213,6 +248,20 @@ var rootType = new GraphQLObjectType({
       resolve: (_, args) => {
         if (args.id !== undefined && args.id !== null) {
           return JSONDataWithPath('/playlists/' + args.id);
+        } else {
+          throw new Error('must provide id');
+        }
+      }
+    },
+    comment: {
+      type: commentType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) }
+      },
+      description: 'Find comment by id',
+      resolve: (_, args) => {
+        if (args.id !== undefined && args.id !== null) {
+          return JSONDataWithPath('/comments/' + args.id);
         } else {
           throw new Error('must provide id');
         }


### PR DESCRIPTION
I tried to add the connections from track and user, but got 401 for both of the urls that I thought would work:
- `curl -v http://api.soundcloud.com/tracks/2/commments?limit=10&client_id=b07703d27fad5e44d82c66195ed9ff03`
- `curl -v http://api.soundcloud.com/users/1717170/commments?limit=10&client_id=b07703d27fad5e44d82c66195ed9ff03`

Not sure why.
